### PR TITLE
DuckHunt: Disable threaded mode

### DIFF
--- a/DuckHunt/plugin.py
+++ b/DuckHunt/plugin.py
@@ -49,8 +49,6 @@ class DuckHunt(callbacks.Plugin):
     when there is no duck launched costs a point.
     """
 
-    threaded = True
-
     # Those parameters are per-channel parameters
     started = {}  # Has the hunt started?
     duck = {}  # Is there currently a duck to shoot?


### PR DESCRIPTION
I don't see any I/O in this plugin, so this doesn't seem to be needed