### PR TITLE
bugfix: produces an error and stops the hunt when that happens

### DIFF
--- a/DuckHunt/plugin.py
+++ b/DuckHunt/plugin.py
@@ -141,10 +141,32 @@ class DuckHunt(callbacks.Plugin):
                 if self.worsttimes[channel][player] > value:
                     self.channelworsttimes[channel][player] = value
 
+        # # week scores
+        # for player, value in self.scores[channel].items():
+        #     # FIXME: If the hunt starts a day and ends the day after, this will produce an error:
+        #     if not player in self.channelweek[channel][self.woy][self.dow]:
+        #         # It's a new player
+        #         self.channelweek[channel][self.woy][self.dow][player] = value
+        #     else:
+        #         # It's a player that already has a saved score
+        #         self.channelweek[channel][self.woy][self.dow][player] += value
+
         # week scores
         for player, value in self.scores[channel].items():
-            # FIXME: If the hunt starts a day and ends the day after, this will produce an error:
-            if not player in self.channelweek[channel][self.woy][self.dow]:
+            # Ensure that the channel exists
+            if channel not in self.channelweek:
+                self.channelweek[channel] = {}
+
+            # Ensure that the week of year (self.woy) exists for the channel
+            if self.woy not in self.channelweek[channel]:
+                self.channelweek[channel][self.woy] = {}
+
+            # Ensure that the day of week (self.dow) exists for the week
+            if self.dow not in self.channelweek[channel][self.woy]:
+                self.channelweek[channel][self.woy][self.dow] = {}
+
+            # Now it's safe to check for the player
+            if player not in self.channelweek[channel][self.woy][self.dow]:
                 # It's a new player
                 self.channelweek[channel][self.woy][self.dow][player] = value
             else:


### PR DESCRIPTION
This hopefully fixes the "If the hunt starts a day and ends the day after, this will produce an error" [here](https://github.com/oddluck/limnoria-plugins/blob/8a87fa68922fc78cd0e1618ba394461000d92ba3/DuckHunt/plugin.py#L146)

I started the hunt on a new channel and every time the hunt finished its cycle it would output an error in the channel like:

_An error has occurred and has been logged. Check the logs for more information._

In the debug log:

> ERROR 2024-10-14T13:02:03 Uncaught exception in ['bang'].
> 
>   File "/home/limnoria/plugins/DuckHunt/plugin.py", line 1059, in bang
>     self._end(irc, msg, args)
>   File "/home/limnoria/plugins/DuckHunt/plugin.py", line 1302, in _end
>     self._calc_scores(currentChannel)
>   File "/home/limnoria/plugins/DuckHunt/plugin.py", line 149, in _calc_scores
>     if not player in self.channelweek[channel][self.woy][self.dow]:
> KeyError: 7

and it would stop the current hunt for that certain channel right after the last 'bang'.
